### PR TITLE
Command example now in markdown code chunk

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ A single exchange rule is either an input rule, defining items that the shop acc
 The stone button items that represent the exchange rules are created using the **/iecreate** (or **/iec**) command. There are three ways of doing this.
  
 - Look at a chest or dispenser containing two different types of items (it's okay if they're spread across multiple stacks), and use **/iec**. This will create an input rule matching the first item type and its quantity, and an output rule matching the second item type and its quantity. Both are placed inside the container, so this shop is immediately ready to be stocked and used.
-- Hold an item in your hand, then use **/iec <input or output>**. This will create an input or output rule matching the held item, and its quantity
-- Use **/iec <input or output> <<i>common name</i> or <i>ID</i>:<i>durability</i>> [<i>amount</i>]**. This will create an input or output rule for the specified item, and optionally the specified amount.
+- Hold an item in your hand, then use **`/iec <input or output>`**. This will create an input or output rule matching the held item, and its quantity
+- Use **`/iec <input or output> <common name or ID:durability> [amount]`**. This will create an input or output rule for the specified item, and optionally the specified amount.
  
 For the second and third options, you need to make sure you have both an input and an output exchange rule, then place them in a suitable container to form an exchange. By adding more input and output rules, you can add more exchanges to your shop, but keep in mind how they are paired.
  

--- a/src/com/untamedears/ItemExchange/command/CommandHandler.java
+++ b/src/com/untamedears/ItemExchange/command/CommandHandler.java
@@ -70,9 +70,9 @@ public class CommandHandler {
 	}
 
 	private void displayCommandHelp(Command cmd, CommandSender sender) {
-		sender.sendMessage(new StringBuilder().append("Â§cCommand:Â§e ").append(cmd.getName()).toString());
-		sender.sendMessage(new StringBuilder().append("Â§cDescription:Â§e ").append(cmd.getDescription()).toString());
-		sender.sendMessage(new StringBuilder().append("Â§cUsage:Â§e ").append(cmd.getUsage()).toString());
+		sender.sendMessage(new StringBuilder().append("§cCommand:§e ").append(cmd.getName()).toString());
+		sender.sendMessage(new StringBuilder().append("§cDescription:§e ").append(cmd.getDescription()).toString());
+		sender.sendMessage(new StringBuilder().append("§cUsage:§e ").append(cmd.getUsage()).toString());
 	}
 
 	private Command getCmdFromIdent(String ident, CommandSender executor) {

--- a/src/com/untamedears/ItemExchange/metadata/BookMetadata.java
+++ b/src/com/untamedears/ItemExchange/metadata/BookMetadata.java
@@ -49,7 +49,7 @@ public class BookMetadata implements AdditionalMetadata {
 		StringBuilder serialized = new StringBuilder();
 		
 		if(title != null && author != null && hasPages) {
-			serialized.append(title).append(ExchangeRule.secondarySpacer).append(author).append(ExchangeRule.hiddenSecondarySpacer).append(bookHash);
+			serialized.append(title).append(ExchangeRule.secondarySpacer).append(author).append(ExchangeRule.secondarySpacer).append(bookHash);
 		}
 		else if(hasPages) {
 			serialized.append(bookHash);

--- a/src/com/untamedears/ItemExchange/utility/ExchangeRule.java
+++ b/src/com/untamedears/ItemExchange/utility/ExchangeRule.java
@@ -46,11 +46,6 @@ import com.untamedears.citadel.entity.Faction;
 public class ExchangeRule {
 	private static final List<Material> NOT_SUPPORTED = Arrays.asList(Material.MAP, Material.WRITTEN_BOOK, Material.ENCHANTED_BOOK, Material.FIREWORK, Material.FIREWORK_CHARGE, Material.POTION);
 	
-//	public static final String hiddenRuleSpacer = "ยง&ยง&ยง&ยง&ยงr";
-//	public static final String hiddenCategorySpacer = "ยง&ยง&ยง&ยงr";
-//	public static final String hiddenSecondarySpacer = "ยง&ยง&ยงr";
-//	public static final String hiddenTertiarySpacer = "ยง&ยงr";
-
 	public static final String hiddenRuleSpacer = "ง&ง&ง&ง&งr";
 	public static final String hiddenCategorySpacer = "ง&ง&ง&งr";
 	public static final String hiddenSecondarySpacer = "ง&ง&งr";
@@ -305,12 +300,11 @@ public class ExchangeRule {
 	}
 
 	/*
-	 * Adds a ยง in front of every character in a string
+	 * Adds a ง in front of every character in a string
 	 */
 	private static String hideString(String string) {
 		String hiddenString = "";
 		for (char character : string.toCharArray()) {
-			//hiddenString += "ยง" + character;
 			hiddenString += "ง" + character;
 		}
 		return hiddenString;
@@ -383,7 +377,6 @@ public class ExchangeRule {
 	public static ItemStack toBulkItemStack(Collection<ExchangeRule> rules) {
 		ItemStack itemStack = ItemExchangePlugin.ITEM_RULE_ITEMSTACK.clone();
 
-		//String ruleSpacer = "ยง&ยง&ยง&ยง&ยงr";
 		String ruleSpacer = "ง&ง&ง&ง&งr";
 
 		ItemMeta itemMeta = itemStack.getItemMeta();

--- a/src/com/untamedears/ItemExchange/utility/ExchangeRule.java
+++ b/src/com/untamedears/ItemExchange/utility/ExchangeRule.java
@@ -46,11 +46,16 @@ import com.untamedears.citadel.entity.Faction;
 public class ExchangeRule {
 	private static final List<Material> NOT_SUPPORTED = Arrays.asList(Material.MAP, Material.WRITTEN_BOOK, Material.ENCHANTED_BOOK, Material.FIREWORK, Material.FIREWORK_CHARGE, Material.POTION);
 	
-	public static final String hiddenRuleSpacer = "ยง&ยง&ยง&ยง&ยงr";
-	public static final String hiddenCategorySpacer = "ยง&ยง&ยง&ยงr";
-	public static final String hiddenSecondarySpacer = "ยง&ยง&ยงr";
-	public static final String hiddenTertiarySpacer = "ยง&ยงr";
+//	public static final String hiddenRuleSpacer = "ยง&ยง&ยง&ยง&ยงr";
+//	public static final String hiddenCategorySpacer = "ยง&ยง&ยง&ยงr";
+//	public static final String hiddenSecondarySpacer = "ยง&ยง&ยงr";
+//	public static final String hiddenTertiarySpacer = "ยง&ยงr";
 
+	public static final String hiddenRuleSpacer = "ง&ง&ง&ง&งr";
+	public static final String hiddenCategorySpacer = "ง&ง&ง&งr";
+	public static final String hiddenSecondarySpacer = "ง&ง&งr";
+	public static final String hiddenTertiarySpacer = "ง&งr";
+	
 	public static final String ruleSpacer = "&&&&r";
 	public static final String categorySpacer = "&&&r";
 	public static final String secondarySpacer = "&&r";
@@ -305,7 +310,8 @@ public class ExchangeRule {
 	private static String hideString(String string) {
 		String hiddenString = "";
 		for (char character : string.toCharArray()) {
-			hiddenString += "ยง" + character;
+			//hiddenString += "ยง" + character;
+			hiddenString += "ง" + character;
 		}
 		return hiddenString;
 	}
@@ -377,7 +383,8 @@ public class ExchangeRule {
 	public static ItemStack toBulkItemStack(Collection<ExchangeRule> rules) {
 		ItemStack itemStack = ItemExchangePlugin.ITEM_RULE_ITEMSTACK.clone();
 
-		String ruleSpacer = "ยง&ยง&ยง&ยง&ยงr";
+		//String ruleSpacer = "ยง&ยง&ยง&ยง&ยงr";
+		String ruleSpacer = "ง&ง&ง&ง&งr";
 
 		ItemMeta itemMeta = itemStack.getItemMeta();
 		itemMeta.setDisplayName(ChatColor.DARK_RED + "Bulk Rule Block");
@@ -482,7 +489,7 @@ public class ExchangeRule {
 		if(citadelGroup != null) {
 			compiledRule += hideString(escapeString(citadelGroup.getName()));
 		}
-		compiledRule += hiddenCategorySpacer + "ยงr";
+		compiledRule += hiddenCategorySpacer + "งr";
 		return compiledRule;
 	}
 


### PR DESCRIPTION
Added backticks to denote start of two examples for the /iec command so the `<input or output>` will actually render.
